### PR TITLE
fix: #6

### DIFF
--- a/packages/core/components/PageProgressBar/index.tsx
+++ b/packages/core/components/PageProgressBar/index.tsx
@@ -27,16 +27,15 @@ export function PageProgressBar() {
     };
   }, []);
 
-  return <Div style={{ transform: `scaleX(${(pageYOffset / offsetHeight) * 100}%)` }} theme={theme}></Div>;
+  return <Div style={{ width: `${(pageYOffset / offsetHeight) * 100}%` }} theme={theme}></Div>;
 }
 
 const Div = styled.div<{ theme: NextUITheme | undefined }>`
   position: fixed;
   top: 0;
   left: 0;
-  width: 100vw;
+  width: 0;
   height: 4px;
   background-color: ${({ theme }) => theme.colors.primary.value};
-  transform-origin: left;
-  transition: transform 0.05s;
+  transition: width 0.05s;
 `;


### PR DESCRIPTION
## 문제

기존 Styled의 props로 state로 넘길 시 class가 계속 generate되기 때문에, 인라인 스타일을 이용해 `transform scaleX`을 이용하여 PageProgressBar 컴포넌트의 너비를 설정하였습니다.

하지만 이 때 인라인으로 -webkit-transform을 따로 설정하지 않아 문제가 발생하였습니다.

## 해결 방법

위에 기술한 이유 때문에 state를 styled props로 이용하는 방법은 지양하는 방법으로 고민하였습니다.

다른 레퍼런스를 참고하던 중, [해당 블로그](https://sreetamdas.com/blog/chameleon-text)에서는 framer-motion을 사용해 계산하긴 하였지만, width 값을 이용해 조절하고 있는 것을 파악하였습니다.

position 값이 fixed이기 때문에 width 값을 지속적으로 수정하여도 reflow가 일어나지 않는 다는 판단하에 width 값을 이용하여 핸들링하는 방향으로 수정하였습니다.