### PR TITLE
refactor: #9

### DIFF
--- a/apps/blog/_config/index.ts
+++ b/apps/blog/_config/index.ts
@@ -1,0 +1,6 @@
+import jsonData from './index.json';
+
+export const blogName = jsonData.blogName;
+export const blogDescription = jsonData.blogDescription;
+export const blogRepo = jsonData.blogRepo;
+export const blogUrl = jsonData.blogUrl;

--- a/apps/blog/src/components/AuthorSection/index.tsx
+++ b/apps/blog/src/components/AuthorSection/index.tsx
@@ -3,8 +3,7 @@ import { Avatar, Link } from '@nextui-org/react';
 import { KBarToggleButton } from 'core';
 
 import { authorImage, authorName, defaultUrl } from 'core/constants';
-import config from '../../../_config/index.json';
-const { blogDescription } = config;
+import { blogDescription } from '../../../_config';
 
 interface Props {
   marginBottom?: string;

--- a/apps/blog/src/components/Comments/index.tsx
+++ b/apps/blog/src/components/Comments/index.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useTheme } from '@nextui-org/react';
-import config from '../../../_config/index.json';
-const { blogRepo } = config;
+import { blogRepo } from '../../../_config';
 
 const src = 'https://utteranc.es/client.js';
 const LIGHT_THEME = 'github-light';

--- a/apps/blog/src/components/Header/MainHeader.tsx
+++ b/apps/blog/src/components/Header/MainHeader.tsx
@@ -2,8 +2,7 @@ import Link from 'next/link';
 import styled from '@emotion/styled';
 import { Text, useTheme, config } from '@nextui-org/react';
 import { KBarToggleButton, ThemeSwitch } from 'core';
-import jsonConfig from '../../../_config/index.json';
-const { blogName } = jsonConfig;
+import { blogName } from '../../../_config';
 
 function MainHeader() {
   const { theme, isDark } = useTheme();

--- a/apps/blog/src/components/Header/PostHeader.tsx
+++ b/apps/blog/src/components/Header/PostHeader.tsx
@@ -2,8 +2,7 @@ import Link from 'next/link';
 import styled from '@emotion/styled';
 import { Text, useTheme } from '@nextui-org/react';
 import { KBarToggleButton, ThemeSwitch } from 'core';
-import config from '../../../_config/index.json';
-const { blogName } = config;
+import { blogName } from '../../../_config';
 
 function PostHeader() {
   const { theme, isDark } = useTheme();

--- a/apps/blog/src/components/SEO/index.tsx
+++ b/apps/blog/src/components/SEO/index.tsx
@@ -1,7 +1,6 @@
 import Head from 'next/head';
 import { authorName, defaultMetaBackground } from 'core/constants';
-import config from '../../../_config/index.json';
-const { blogName, blogDescription } = config;
+import { blogName, blogDescription } from '../../../_config';
 
 interface Props {
   title?: string | undefined;

--- a/apps/blog/src/pages/_document.tsx
+++ b/apps/blog/src/pages/_document.tsx
@@ -2,10 +2,7 @@ import Document, { Html, Head, Main, NextScript } from 'next/document';
 import { CssBaseline } from '@nextui-org/react';
 import { Footer, GlobalStyle, Layout } from 'core';
 import { authorName, blogGAID, blogHotjarID, favicon } from 'core/constants';
-
-// Should not import the named export from default-exporting module (only default export is available soon)
-import config from '../../_config/index.json';
-const { blogUrl } = config;
+import { blogUrl } from '../../_config';
 
 function isValid(value: any) {
   if (typeof value === 'string' && value.length > 0) return true;

--- a/apps/resume/_config/index.ts
+++ b/apps/resume/_config/index.ts
@@ -1,0 +1,5 @@
+import jsonData from './index.json';
+
+export const resumeUrl = jsonData.resumeUrl;
+export const blogUrl = jsonData.blogUrl;
+export const email = jsonData.email;

--- a/apps/resume/src/constants/KbarActions/KbarActions.ts
+++ b/apps/resume/src/constants/KbarActions/KbarActions.ts
@@ -1,7 +1,6 @@
 import { IconActionType, socialActions } from 'core/constants';
 import { openExternalLink } from 'core/utils';
-import config from '../../../_config/index.json';
-const { blogUrl, email } = config;
+import { blogUrl, email } from '../../../_config';
 
 function openEmailTo(href: string) {
   Object.assign(document.createElement('a'), { href: `mailto:${href}` }).click();

--- a/apps/resume/src/pages/_document.tsx
+++ b/apps/resume/src/pages/_document.tsx
@@ -3,6 +3,7 @@ import { CssBaseline } from '@nextui-org/react';
 import { Footer, GlobalStyle, Layout } from 'core';
 import { authorImage, authorName, favicon } from 'core/constants';
 import { data } from '../../_content/Header';
+import { resumeUrl } from '../../_config';
 
 const TITLE = `${authorName} resume`;
 export default class ResumeDocument extends Document {
@@ -17,10 +18,12 @@ export default class ResumeDocument extends Document {
           <meta httpEquiv="Content-type" content="text/html; charset=utf-8" />
           <meta httpEquiv="x-ua-compatible" content="ie=edge" />
           <meta name="description" content={data.description} />
+          <link rel="canonical" href={resumeUrl} />
           <meta name="keywords" content="resume,development,developer" />
           <meta property="og:type" content="website" />
           <meta property="og:locale" content="ko_KR" />
           <meta property="og:title" content={TITLE} />
+          <meta property="og:url" content={resumeUrl} />
           <meta property="og:description" content={data.description} />
           <meta property="og:image" content={authorImage.default.src} />
           {/* for korean keywords */}


### PR DESCRIPTION
기존 json 파일을 destructing import를 할 수 없어, 사용처에서 import 후 destructing 하였습니다.

이를 refactoring하기 위해 _config directory의 index 파일을 두어 export한 후, 사용처에서 아래와 같은 모습으로 사용할 수 있게끔 하였습니다.

```tsx
import {.blogUrl } from "../_config";
```