### PR TITLE
Apply test at Resume constants

### DIFF
--- a/apps/resume/src/constants/KbarActions/KbarActions.test.ts
+++ b/apps/resume/src/constants/KbarActions/KbarActions.test.ts
@@ -1,0 +1,31 @@
+import generateKbarActions from './KbarActions';
+
+const mockConfig = jest.requireMock('../../../_config');
+jest.mock('../../../_config');
+
+const mockSocialActions = jest.requireMock('core/constants');
+jest.mock('core/constants');
+
+describe('resume - constants - KbarActions', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('should return blog url and email', () => {
+    mockConfig.blogUrl = 'mock blogurl';
+    mockConfig.email = 'mock email';
+    mockSocialActions.socialActions = [];
+
+    const kbarActions = generateKbarActions();
+    expect(kbarActions.length).toBe(2);
+  });
+
+  it('should not return blog url and email when null and empty string', () => {
+    mockConfig.blogUrl = '';
+    mockConfig.email = null;
+    mockSocialActions.socialActions = [];
+
+    const kbarActions = generateKbarActions();
+    expect(kbarActions.length).toBe(0);
+  });
+});

--- a/apps/resume/src/constants/KbarActions/KbarActions.ts
+++ b/apps/resume/src/constants/KbarActions/KbarActions.ts
@@ -3,19 +3,15 @@ import { openExternalLink } from 'core/utils';
 
 import { blogUrl, email } from '../../../_config';
 
-function openEmailTo(href: string) {
-  Object.assign(document.createElement('a'), { href: `mailto:${href}` }).click();
-}
-
 function generateKbarAction() {
   const KbarActions: IconActionType[] = [...socialActions];
 
-  function pushLeftWhenValid(value: string | null, action: IconActionType) {
-    if (typeof value !== 'string') return;
+  function unshiftWhenValid(value: string | null, action: IconActionType) {
+    if (typeof value !== 'string' || value.length < 1) return;
     KbarActions.unshift(action);
   }
 
-  pushLeftWhenValid(blogUrl, {
+  unshiftWhenValid(blogUrl, {
     id: 'blog',
     name: 'Blog',
     subtitle: blogUrl,
@@ -26,7 +22,7 @@ function generateKbarAction() {
     perform: () => openExternalLink(blogUrl),
   });
 
-  pushLeftWhenValid(email, {
+  unshiftWhenValid(email, {
     id: 'email',
     name: 'Email',
     subtitle: email,
@@ -34,7 +30,7 @@ function generateKbarAction() {
     shortcut: [],
     keywords: 'contact, email, mail',
     icon: 'Email',
-    perform: () => openEmailTo(email),
+    perform: () => openExternalLink(`mailto:${email}`),
   });
 
   return KbarActions;

--- a/apps/resume/src/constants/KbarActions/index.test.ts
+++ b/apps/resume/src/constants/KbarActions/index.test.ts
@@ -1,0 +1,11 @@
+import defaultFunction from './index';
+import generateKbarAction from './KbarActions';
+
+describe('resume - constants - KbarActions index', () => {
+  it('should return same', () => {
+    const defaultResult = defaultFunction();
+    const kbarActionsResult = generateKbarAction();
+
+    expect(JSON.stringify(defaultResult)).toEqual(JSON.stringify(kbarActionsResult));
+  });
+});


### PR DESCRIPTION
Apply test code at Resume app's constant directory

and refactor it

## as is

using `openEmailTo` function for anchor tag with `emailto:`

## to be

replace `openExternalLink` utils at core


