### PR TITLE
Apply e2e test at blog root scroll restoration

### DIFF
--- a/apps/blog/cypress/e2e/root/store-restoration.spec.ts
+++ b/apps/blog/cypress/e2e/root/store-restoration.spec.ts
@@ -1,0 +1,15 @@
+describe('root - store restoration', () => {
+  it('should restore scroll position when reload', () => {
+    const SCROLL_Y_POSITION = 200;
+
+    cy.visit('/');
+    cy.window().then($window => {
+      $window.scrollTo(0, SCROLL_Y_POSITION);
+    });
+
+    cy.reload();
+    cy.wait(2000);
+
+    cy.window().its('scrollY').should('eq', SCROLL_Y_POSITION);
+  });
+});

--- a/packages/config/eslint-nextjs.js
+++ b/packages/config/eslint-nextjs.js
@@ -56,6 +56,8 @@ module.exports = {
     'import/default': 'off',
     'react/jsx-key': 'off',
     '@next/next/no-html-link-for-pages': 'off',
+
+    'cypress/no-unnecessary-waiting': 'off',
   },
   overrides: [
     {


### PR DESCRIPTION
<!-- Please check lint, test, cypress -->

## Description

- disable cypress lint `no-unnecessary-waiting` rule for waiting scroll restoration
- apply e2e test code at `blog`'s root scroll restoration
