### PR TITLE
Apply e2e test at blog slug page's header

### DIFF
--- a/apps/blog/cypress.config.ts
+++ b/apps/blog/cypress.config.ts
@@ -10,5 +10,6 @@ export default defineConfig({
     },
     specPattern: 'cypress/e2e/**/*.{js,jsx,ts,tsx}',
     baseUrl: 'http://localhost:3000/',
+    defaultCommandTimeout: 30000,
   },
 });

--- a/apps/blog/cypress/e2e/root/header.spec.ts
+++ b/apps/blog/cypress/e2e/root/header.spec.ts
@@ -43,9 +43,7 @@ describe('root - header', () => {
   });
 
   it('should render kbar menu when click kbar button', () => {
-    cy.get('header').within(() => {
-      cy.get('button').click();
-    });
+    cy.get('header').find('button').click();
 
     cy.get('input').should('be.visible');
   });

--- a/apps/blog/cypress/e2e/slug/header.spec.ts
+++ b/apps/blog/cypress/e2e/slug/header.spec.ts
@@ -1,0 +1,37 @@
+describe('slug - nav', () => {
+  it('should linkable to slug', () => {
+    cy.visit('/');
+    cy.get('main').find('a').first().click();
+    cy.url().should('not.eq', Cypress.config().baseUrl);
+  });
+
+  it('should render level 3 heading inside of header', () => {
+    cy.get('header').find('h3').should('exist');
+  });
+
+  const THEME_SWITCH_LABEL = 'theme switch';
+  const GET_THEME_SWITCH_BY_LABEL = `[aria-label="${THEME_SWITCH_LABEL}"]`;
+
+  it('should render theme toggle switch and kbar button at inside of header', () => {
+    cy.get('header').within(() => {
+      cy.get(GET_THEME_SWITCH_BY_LABEL).should('exist');
+
+      cy.get('button').should('exist');
+    });
+  });
+
+  it('should toggle theme when click theme toggle switch', () => {
+    cy.get('body').then($body => {
+      const currentBgColor = $body.css('background-color');
+
+      cy.get('header').find(GET_THEME_SWITCH_BY_LABEL).click();
+      cy.get('body').should('have.css', 'background-color').and('not.eq', currentBgColor);
+    });
+  });
+
+  it('should render kbar menu when click kbar button', () => {
+    cy.get('header').find('button').click();
+
+    cy.get('input').should('be.visible');
+  });
+});

--- a/apps/blog/cypress/e2e/slug/header.spec.ts
+++ b/apps/blog/cypress/e2e/slug/header.spec.ts
@@ -1,4 +1,4 @@
-describe('slug - nav', () => {
+describe('slug - header', () => {
   it('should linkable to slug', () => {
     cy.visit('/');
     cy.get('main').find('a').first().click();


### PR DESCRIPTION
<!-- Please check lint, test, cypress -->

## Description

- apply e2e test code at `blog slug page's header`
- replace some `cy.within` to `find` method