### PR TITLE
Remain author section kbar button size and Update header word break attr

### DIFF
--- a/apps/blog/src/components/AuthorSection/AuthorSection.tsx
+++ b/apps/blog/src/components/AuthorSection/AuthorSection.tsx
@@ -27,7 +27,11 @@ function AuthorSection({ marginBottom = '3.5rem', hasKbarButton = false }: Props
         </TextWrapper>
       </Div>
 
-      {hasKbarButton && <KBarToggleButton />}
+      {hasKbarButton && (
+        <KbarButtonWrapper>
+          <KBarToggleButton />
+        </KbarButtonWrapper>
+      )}
     </Section>
   );
 }
@@ -61,4 +65,8 @@ const TextWrapper = styled.div`
 
 const H2 = styled.h2`
   font-weight: normal;
+`;
+
+const KbarButtonWrapper = styled.div`
+  flex-grow: 1;
 `;

--- a/apps/blog/src/components/Header/MainHeader.tsx
+++ b/apps/blog/src/components/Header/MainHeader.tsx
@@ -29,6 +29,7 @@ const Header = styled.header`
   justify-content: space-between;
   align-items: flex-end;
   margin-bottom: 0.875rem;
+  word-break: break-word;
 `;
 
 const H1 = styled(Text)`

--- a/apps/blog/src/components/Header/PostHeader.tsx
+++ b/apps/blog/src/components/Header/PostHeader.tsx
@@ -29,6 +29,7 @@ const Header = styled.header`
   justify-content: space-between;
   align-items: center;
   margin-bottom: 2.25rem;
+  word-break: break-word;
 `;
 
 const H3 = styled(Text)`


### PR DESCRIPTION
<!-- Please check lint, test, cypress -->

## Description

- append `flex-grow: 1` at `AuthorSection`'s kbar button to remain button size
- append `word-break: break-word` attr at `MainHeader` and `PostHeader` to prevent overflow button wrapper