### PR TITLE
Apply Html code to WorkExperience

### DIFF
--- a/apps/resume/src/components/WorkExperienceSection/Project.tsx
+++ b/apps/resume/src/components/WorkExperienceSection/Project.tsx
@@ -16,7 +16,7 @@ function Project({ title, description, startDate, endDate, which, techStack }: I
       </small>
       <span>{description}</span>
       {which.length > 0 && (
-        <ul>
+        <ul data-testid="which wrapper">
           {which.map((each, index) => (
             <Li key={index} theme={theme} dangerouslySetInnerHTML={{ __html: each }}>
               {each}

--- a/apps/resume/src/components/WorkExperienceSection/Project.tsx
+++ b/apps/resume/src/components/WorkExperienceSection/Project.tsx
@@ -16,9 +16,9 @@ function Project({ title, description, startDate, endDate, which, techStack }: I
       </small>
       <span>{description}</span>
       {which.length > 0 && (
-        <ul data-testid="which wrapper">
+        <ul>
           {which.map((each, index) => (
-            <Li key={index} theme={theme}>
+            <Li key={index} theme={theme} dangerouslySetInnerHTML={{ __html: each }}>
               {each}
             </Li>
           ))}

--- a/apps/resume/src/components/WorkExperienceSection/Project.tsx
+++ b/apps/resume/src/components/WorkExperienceSection/Project.tsx
@@ -18,9 +18,7 @@ function Project({ title, description, startDate, endDate, which, techStack }: I
       {which.length > 0 && (
         <ul data-testid="which wrapper">
           {which.map((each, index) => (
-            <Li key={index} theme={theme} dangerouslySetInnerHTML={{ __html: each }}>
-              {each}
-            </Li>
+            <Li key={index} theme={theme} dangerouslySetInnerHTML={{ __html: each }} />
           ))}
         </ul>
       )}


### PR DESCRIPTION
## Description

WorkExperience(프로젝트 경험)에 Html 태그를 사용할 수 있도록 하였습니다.

dangerouslySetInnerHTML을 사용하여 작성하였습니다. 
```html
{which.map((each, index) => (
     <Li key={index} theme={theme} dangerouslySetInnerHTML={{ __html: each }}>
         {each}
     </Li>
))}
 ```